### PR TITLE
No export member 'Dictionary'

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser": "^9.1.1",
     "@angular/platform-browser-dynamic": "^9.1.1",
     "@angular/router": "^9.1.1",
+    "@jsplumb/util": "5.0.8",
     "@jsplumbtoolkit/browser-ui-angular": "^5.0.0",
     "@jsplumbtoolkit/browser-ui-angular-drop": "^5.0.0",
     "@jsplumbtoolkit/browser-ui-plugin-miniview": "^5.0.0",


### PR DESCRIPTION
**Issue description**

I clone angular-database-visualizer demo, run` npm install `and `npm run start`.

I get the following output when starting the application:

```
> angular-database-visualizer ng serve


chunk {main} main.js, main.js.map (main) 2.06 kB [initial] [rendered]
chunk {polyfills} polyfills.js, polyfills.js.map (polyfills) 707 bytes [initial] [rendered]
chunk {runtime} runtime.js, runtime.js.map (runtime) 6.15 kB [entry] [rendered]
chunk {styles} styles.js, styles.js.map (styles) 79.8 kB [initial] [rendered]
chunk {vendor} vendor.js, vendor.js.map (vendor) 346 kB [initial] [rendered]
Date: 2021-12-01T15:36:14.037Z - Hash: 1f585f39b0ed68ebe59a - Time: 5680ms

ERROR in node_modules/@jsplumbtoolkit/browser-ui/browser-ui.d.ts:20:10 - error TS2305: Module '"../../@jsplumb/util/util"' has no exported member 'Dictionary'.

20 import { Dictionary } from '@jsplumb/util';
            ~~~~~~~~~~
node_modules/@jsplumbtoolkit/dialogs/dialogs.d.ts:1:10 - error TS2305: Module '"../../@jsplumb/util/util"' has no exported member 'Dictionary'.

1 import { Dictionary } from '@jsplumb/util';
           ~~~~~~~~~~
node_modules/@jsplumbtoolkit/layout-spring/layout-spring.d.ts:3:10 - error TS2305: Module '"../../@jsplumb/util/util"' has no exported member 'Dictionary'.

3 import { Dictionary } from '@jsplumb/util';
           ~~~~~~~~~~
```

**Possible solution**

It appears that there is a misconfiguration issue with the package.json dependencies.
Using `"@jsplumbtoolkit/browser-ui-angular": "^5.0.0"` imports browser-ui v5.0.8, which gets @jsplumb/utils v5.2.1.
When specifying :
`"@jsplumb/util": "5.0.8"` it fixes the issue.

Could you help me look onto it ?
